### PR TITLE
Foods in Expired and Expiring Lists are sorted by Description if same Expiry

### DIFF
--- a/src/main/java/seedu/simplykitchen/model/ModelManager.java
+++ b/src/main/java/seedu/simplykitchen/model/ModelManager.java
@@ -3,6 +3,8 @@ package seedu.simplykitchen.model;
 import static java.util.Objects.requireNonNull;
 import static seedu.simplykitchen.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.simplykitchen.model.util.ComparatorUtil.SORT_BY_ASCENDING_EXPIRY_DATE;
+import static seedu.simplykitchen.model.util.ComparatorUtil.SORT_BY_FIRST_CHARACTER;
+import static seedu.simplykitchen.model.util.ComparatorUtil.SORT_BY_LEXICOGRAPHICAL_ORDER;
 import static seedu.simplykitchen.model.util.ComparatorUtil.generateSortingComparatorsDescription;
 import static seedu.simplykitchen.model.util.ComparatorUtil.getComparator;
 
@@ -222,6 +224,9 @@ public class ModelManager implements Model {
     // ============== Expiring Food List ========================================================================
     @Override
     public void updateExpiringSortedFoodList() {
+        // Priority was not considered as priority cannot be seen on the expired/expiring lists
+        expiringSortedFoods.setComparator(SORT_BY_LEXICOGRAPHICAL_ORDER);
+        expiringSortedFoods.setComparator(SORT_BY_FIRST_CHARACTER);
         expiringSortedFoods.setComparator(SORT_BY_ASCENDING_EXPIRY_DATE);
     }
 

--- a/src/main/java/seedu/simplykitchen/model/ModelManager.java
+++ b/src/main/java/seedu/simplykitchen/model/ModelManager.java
@@ -225,6 +225,7 @@ public class ModelManager implements Model {
     @Override
     public void updateExpiringSortedFoodList() {
         // Priority was not considered as priority cannot be seen on the expired/expiring lists
+        expiringSortedFoods.setComparator(null);
         expiringSortedFoods.setComparator(SORT_BY_LEXICOGRAPHICAL_ORDER);
         expiringSortedFoods.setComparator(SORT_BY_FIRST_CHARACTER);
         expiringSortedFoods.setComparator(SORT_BY_ASCENDING_EXPIRY_DATE);

--- a/src/main/java/seedu/simplykitchen/model/ModelManager.java
+++ b/src/main/java/seedu/simplykitchen/model/ModelManager.java
@@ -2,9 +2,7 @@ package seedu.simplykitchen.model;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.simplykitchen.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.simplykitchen.model.util.ComparatorUtil.SORT_BY_ASCENDING_EXPIRY_DATE;
-import static seedu.simplykitchen.model.util.ComparatorUtil.SORT_BY_FIRST_CHARACTER;
-import static seedu.simplykitchen.model.util.ComparatorUtil.SORT_BY_LEXICOGRAPHICAL_ORDER;
+import static seedu.simplykitchen.model.util.ComparatorUtil.SORT_BY_DESC_THEN_ASC_EXPIRY;
 import static seedu.simplykitchen.model.util.ComparatorUtil.generateSortingComparatorsDescription;
 import static seedu.simplykitchen.model.util.ComparatorUtil.getComparator;
 
@@ -224,11 +222,7 @@ public class ModelManager implements Model {
     // ============== Expiring Food List ========================================================================
     @Override
     public void updateExpiringSortedFoodList() {
-        // Priority was not considered as priority cannot be seen on the expired/expiring lists
-        expiringSortedFoods.setComparator(null);
-        expiringSortedFoods.setComparator(SORT_BY_LEXICOGRAPHICAL_ORDER);
-        expiringSortedFoods.setComparator(SORT_BY_FIRST_CHARACTER);
-        expiringSortedFoods.setComparator(SORT_BY_ASCENDING_EXPIRY_DATE);
+        expiringSortedFoods.setComparator(SORT_BY_DESC_THEN_ASC_EXPIRY);
     }
 
     @Override

--- a/src/main/java/seedu/simplykitchen/model/util/ComparatorUtil.java
+++ b/src/main/java/seedu/simplykitchen/model/util/ComparatorUtil.java
@@ -31,6 +31,8 @@ public class ComparatorUtil {
                 food1.getDescription().fullDescription.compareTo(food2.getDescription().fullDescription);
     public static final Comparator<Food> SORT_BY_FIRST_CHARACTER = (food1, food2) ->
                 food1.getDescription().compareFirstCharacterTo(food2.getDescription());
+    public static final Comparator<Food> SORT_BY_DESC_THEN_ASC_EXPIRY = SORT_BY_ASCENDING_EXPIRY_DATE
+            .thenComparing(SORT_BY_FIRST_CHARACTER).thenComparing(SORT_BY_LEXICOGRAPHICAL_ORDER);
 
     /**
      * Returns the foodInventorySortingComparators information according to {@code comparatorDescription}.


### PR DESCRIPTION
Previously, food items with the same expiry dates will change their ordering in the expired and expiring lists after editing their fields.

Can be reproduced by having two food items with the same expiry dates. Edit the field of the food item lower on the list while still maintaining same expiry dates. The one that was below will now be on top.

Now the lists are sorted by description then expiry (i.e food items with descriptions "a" and "b" with same expiry dates will always be ordered "a" then "b" even after editing)