### PR TITLE
Fix formatting of error messages

### DIFF
--- a/src/main/java/seedu/simplykitchen/logic/commands/ChangeQuantityCommand.java
+++ b/src/main/java/seedu/simplykitchen/logic/commands/ChangeQuantityCommand.java
@@ -28,9 +28,9 @@ public class ChangeQuantityCommand extends Command {
 
     public static final String COMMAND_WORD = "changeqty";
 
-    public static final String MESSAGE_USAGE = " Usage: " + COMMAND_WORD + " INDEX "
+    public static final String MESSAGE_USAGE = "Usage: " + COMMAND_WORD + " INDEX "
             + PREFIX_AMOUNT + "AMOUNT\n"
-            + "Example: " + COMMAND_WORD + " 1 "
+            + "  Example: " + COMMAND_WORD + " 1 "
             + PREFIX_AMOUNT + "+1";
 
     public static final String MESSAGE_SUCCESS = "The following food item has its quantity changed:\n  %1$s";

--- a/src/main/java/seedu/simplykitchen/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/simplykitchen/logic/parser/ParserUtil.java
@@ -22,7 +22,7 @@ public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index should be a non-zero unsigned integer.";
     public static final String MESSAGE_INVALID_AMOUNT =
-            "Amount should be a non-zero signed number with a maximum of 2 decimal places. "
+            "Amount should be a non-zero signed number with a maximum of 2 decimal places.\n"
             + "It should be more than -100000.00 and less than +100000.00 but not zero.";
 
     /**

--- a/src/main/java/seedu/simplykitchen/model/food/ExpiryDate.java
+++ b/src/main/java/seedu/simplykitchen/model/food/ExpiryDate.java
@@ -16,7 +16,7 @@ import java.time.format.DateTimeParseException;
 public class ExpiryDate {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "The expiry date should be a valid date of the format DD-MM-YYYY or DD/MM/YYYY. "
+            "The expiry date should be a valid date of the format DD-MM-YYYY or DD/MM/YYYY.\n"
                     + "The year should be between 2020 and 2120, both inclusive.";
     public static final String DATE_PATTERN = "d-M-yyyy";
 


### PR DESCRIPTION
The spacing for the change quantity command usage is the same as the
rest.

Error messages for invalid expiry dates and amounts are now 2 lines
instead of 1 line.